### PR TITLE
Force disable Jetpack's site stats module

### DIFF
--- a/client-mu-plugins/vipgo-remove-jp-stats.php
+++ b/client-mu-plugins/vipgo-remove-jp-stats.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Force disable the force enabled stats component of Jetpack.
+ *
+ * See <https://wordpressvip.zendesk.com/hc/en-us/requests/106596> for more
+ * info.
+ * @author: https://github.com/mikeyarce
+ */
+
+// Disable the Stats Jetpack Module
+add_filter( 'jetpack_active_modules', 'vipgo_override_jp_modules', 99, 9 );
+
+function vipgo_override_jp_modules( $modules ) {
+	$disabled_modules = array(
+		'stats',
+	);
+
+	foreach ( $disabled_modules as $module_slug ) {
+		$found = array_search( $module_slug, $modules, true );
+		if ( false !== $found ) {
+			unset( $modules[ $found ] );
+		}
+	}
+	return $modules;
+}
+
+// Remove Stats from the list of Jetpack modules
+add_filter( 'jetpack_get_available_modules', 'vipgo_jetpack_hide_stats_module' );
+function vipgo_jetpack_hide_stats_module( $modules ) {
+	if( isset( $modules['stats'] ) ) {
+		unset( $modules['stats'] );
+	}
+	return $modules;
+}


### PR DESCRIPTION
wpvip hides the controls to disable this module via normal means, so we
have to use filters to munge the configuration. Not ideal, but nicer
than having an unwanted tracking beacon on the site.

Bug: T247569