### PR TITLE
Add disable-emojis plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "plugins/co-authors-plus"]
 	path = plugins/co-authors-plus
 	url = https://github.com/Automattic/Co-Authors-Plus
+[submodule "plugins/disable-emojis"]
+	path = plugins/disable-emojis
+	url = https://github.com/ryanhellyer/disable-emojis


### PR DESCRIPTION
Add Ryan Hellyer's Disable Emojis plugin to disable core WordPress
functionality of loading png images to replace unicode emoji glyphs.

Bug: T259421