### PR TITLE
modern-child: Show Co-Authors Plus authors in RSS feed

### DIFF
--- a/themes/modern-child/functions.php
+++ b/themes/modern-child/functions.php
@@ -36,3 +36,13 @@ add_filter( 'wp_headers', function( $headers ) {
     }
     return $headers;
 }, 999 );
+
+/**
+ * Show co-authors plus authors in RSS feed.
+ */
+add_filter( 'the_author', function( $display_name ) {
+	if ( is_feed() && function_exists( 'coauthors' ) ) {
+		$display_name = coauthors( null, null, null, null, false );
+	}
+	return $display_name;
+} );


### PR DESCRIPTION
Add a filter handler for 'the_author' that will return co-authors plus
author data when RSS feeds are being generated.

Bug: T250870