### PR TITLE
Update vip-config.php to redirect techblog to diff

### DIFF
--- a/vip-config/vip-config.php
+++ b/vip-config/vip-config.php
@@ -37,4 +37,4 @@ if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
 		header( 'Location: https://' . $redirect_to_domain . $request_uri, true, 301 );
 		exit;
 	}
-} t
+}

--- a/vip-config/vip-config.php
+++ b/vip-config/vip-config.php
@@ -15,3 +15,26 @@
  *
  * - The WordPress.com VIP Team
  **/
+if ( isset( $_SERVER['HTTP_HOST'] ) && isset( $_SERVER['REQUEST_URI'] ) ) {
+	$http_host   = $_SERVER['HTTP_HOST']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	$request_uri = $_SERVER['REQUEST_URI']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+	$redirect_to_domain = 'diff.wikimedia.org';
+	$redirect_domains   = array(
+		'techblog.wikimedia.org',
+	);
+
+	/**
+	 * Safety checks for redirection:
+	 * 1. Don't redirect for '/cache-healthcheck?' or monitoring will break
+	 * 2. Don't redirect in WP CLI context
+	 */
+	if (
+			'/cache-healthcheck?' !== $request_uri && // Do not redirect VIP's monitoring.
+			! ( defined( 'WP_CLI' ) && WP_CLI ) && // Do not redirect WP-CLI commands.
+			$redirect_to_domain !== $http_host && in_array( $http_host, $redirect_domains, true )
+		) {
+		header( 'Location: https://' . $redirect_to_domain . $request_uri, true, 301 );
+		exit;
+	}
+} t


### PR DESCRIPTION
As [announced](https://techblog.wikimedia.org/2026/02/24/a-tech-blog-diff/) the Techblog is migrating to Diff. According to WordPress VIP (both their [documentation](https://docs.wpvip.com/redirects/domain-redirects-in-vip-config-php/) and in a request to their customer service) this is the method to redirect between two VIP hosted domains. 